### PR TITLE
Change powerlevel9k_init to prompt_powerlevel9k_setup

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1040,7 +1040,7 @@ $(print_icon 'MULTILINE_SECOND_PROMPT_PREFIX')"
   fi
 }
 
-powerlevel9k_init() {
+prompt_powerlevel9k_setup() {
   # Display a warning if the terminal does not support 256 colors
   local term_colors
   term_colors=$(echotc Co)
@@ -1092,5 +1092,5 @@ powerlevel9k_init() {
   add-zsh-hook precmd powerlevel9k_prepare_prompts
 }
 
-powerlevel9k_init "$@"
+prompt_powerlevel9k_setup "$@"
 


### PR DESCRIPTION
Changed init/setup function name to be compatible with zsh promptinit, zsh prompt function only lists themes with prompt_*_setup init/setup functions